### PR TITLE
Add Com Day Checklist

### DIFF
--- a/Competition/Comp Day.md
+++ b/Competition/Comp Day.md
@@ -2,7 +2,7 @@
 
 ### 1. Radio Configuration
 - Bring a second radio for easier swapping.
-- **Remember to obtain the robot WIFI password while configuring radio.**
+- **Remember to obtain the robot Wi-Fi password while configuring radio.**
 
 ### 2. Field Calibration
 **Supplies Needed:**


### PR DESCRIPTION
This pull request adds a new competition day checklist to help the team prepare and operate smoothly during events. The checklist covers radio configuration, field calibration steps, and post-competition procedures.

Competition preparation documentation:

* Added a `Competition Day Checklist` in `Competition/Comp Day.md` with sections for radio setup, field calibration supplies and steps, and end-of-competition tasks.